### PR TITLE
Add AITRIAGE to Loki scripts

### DIFF
--- a/triage/aitriage-to-loki/README.md
+++ b/triage/aitriage-to-loki/README.md
@@ -1,0 +1,9 @@
+AITRIAGE logs to Loki
+====
+
+These two scripts help with triaging assisted-installer failures. Looking into separate files makes it complicated to correlate particular events from multiple sources - i.e. bootkube log and infraenv/cluster events.
+
+`run-loki.py` runs Loki+Promtail+Grafana stack preconfigured to parse AITRIAGE logs collected for particular failure. It runs as Podman pod locally, reading data from `/tmp/aitriage-loki`.
+
+`unpack.py` script fetches files from logs storage - `python unpack.py http://assisted-logs-collector.usersys.redhat.com/files/<timestamp>_<cluster_id>`, unpacks stored tars and copies it to `/tmp/aitriage-loki`.
+Promtail running in the background parses the files and loads them in Loki. Grafana is used to query logs via cluster ID / event source / systemd service etc.

--- a/triage/aitriage-to-loki/podman/grafana/grafana.ini
+++ b/triage/aitriage-to-loki/podman/grafana/grafana.ini
@@ -1,0 +1,10 @@
+[auth.anonymous]
+enabled = true
+org_role = Editor
+
+[log]
+level = debug
+mode = console
+
+[paths]
+provisioning = /etc/grafana/provisioning/

--- a/triage/aitriage-to-loki/podman/grafana/provisioning/datasources/loki.yml
+++ b/triage/aitriage-to-loki/podman/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://localhost:3100
+    jsonData:
+      maxLines: 1000

--- a/triage/aitriage-to-loki/podman/loki/local-config.yaml
+++ b/triage/aitriage-to-loki/podman/loki/local-config.yaml
@@ -1,0 +1,34 @@
+auth_enabled: false
+chunk_store_config:
+  max_look_back_period: 0
+ingester:
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    interface_names: [tap0]
+  max_transfer_retries: 0
+limits_config:
+  enforce_metric_name: false
+  reject_old_samples: false
+  max_entries_limit_per_query: 0
+schema_config:
+  configs:
+  - from: '2018-04-15'
+    index:
+      period: 168h
+      prefix: index_
+    object_store: filesystem
+    schema: v9
+    store: boltdb
+server:
+  http_listen_port: 3100
+storage_config:
+  boltdb:
+    directory: "/srv/loki/index"
+  filesystem:
+    directory: "/srv/loki/chunks"
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0

--- a/triage/aitriage-to-loki/podman/pod.yml
+++ b/triage/aitriage-to-loki/podman/pod.yml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: aitriage-to-loki
+  name: aitriage-to-loki
+spec:
+  containers:
+  - image: docker.io/grafana/loki:2.4.2
+    name: loki
+    ports:
+    - hostPort: 3100
+    volumeMounts:
+    - mountPath: /etc/loki:Z
+      name: loki-config
+    - mountPath: /srv/loki:z
+      name: loki-data
+    securityContext:
+      runAsUser: 0
+  - image: docker.io/grafana/grafana:8.4.5
+    name: grafana
+    ports:
+    - hostPort: 3000
+    volumeMounts:
+    - mountPath: /etc/grafana:Z
+      name: grafana-config
+  - image: docker.io/grafana/promtail:2.4.1
+    name: promtail
+    volumeMounts:
+    - mountPath: /etc/promtail:Z
+      name: promtail-config
+    - mountPath: /run/promtail:Z
+      name: promtail-data
+    - mountPath: /var/log:z
+      name: log-data
+  volumes:
+  - hostPath:
+      path: podman/loki
+      type: Directory
+    name: loki-config
+  - hostPath:
+      path: podman/promtail
+      type: Directory
+    name: promtail-config
+  - hostPath:
+      path: podman/grafana
+      type: Directory
+    name: grafana-config
+  - hostPath:
+      path: foo/promtail-data
+      type: Directory
+    name: promtail-data
+  - hostPath:
+      path: foo/loki-data
+      type: Directory
+    name: loki-data
+  - hostPath:
+      path: foo
+      type: Directory
+    name: log-data

--- a/triage/aitriage-to-loki/podman/promtail/config.yml
+++ b/triage/aitriage-to-loki/podman/promtail/config.yml
@@ -1,0 +1,171 @@
+server:
+  disable: true
+clients:
+  - url: http://127.0.0.1:3100/api/prom/push
+positions:
+  filename: /tmp/positions.yaml
+scrape_configs:
+- job_name: hosts
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: hosts-logs
+      __path__: /var/log/*/cluster_*_logs/logs_host_*/{agent,bootkube,installer}.logs
+  pipeline_stages:
+    - match:
+        selector: '{job="hosts-logs"}'
+        stages:
+        - regex:
+           source: filename
+           expression: '/var/log/.*/cluster_(?P<cluster_id>\S+?)_logs/logs_host_(?P<host_id>\S+?)/(?P<service>\S+?).logs'
+        - labels:
+           service:
+           host_id:
+           cluster_id:
+        - match:
+            selector: '{service=~"bootkube|agent"}'
+            stages:
+            - regex:
+                expression: '(?P<time>\S+\s\d+\s\S+?) (?P<hostname>\S+?) (?P<systemd_service>\S+?)\[\S+\]: (?P<message>.*)'
+            - timestamp:
+                source: time
+                format: Jan 02 15:04:05
+            - labels:
+                hostname:
+                systemd_service:
+            - output:
+                source: message
+        - match:
+            selector: '{service="installer"}'
+            stages:
+            - regex:
+                expression: 'time="(?P<timestamp>[\w+T\d-:.Z]+)" level=(?P<level>[a-zA-Z]+) msg="(?P<msg>.+)"'
+            - timestamp:
+                source: timestamp
+                format: RFC3339Nano
+            - labels:
+                level:
+            - output:
+                source: msg
+- job_name: controller
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: controller-logs
+      __path__: /var/log/*/cluster_*_logs/assisted-installer-controller*.logs
+  pipeline_stages:
+    - match:
+        selector: '{job="controller-logs"}'
+        stages:
+        - regex:
+            source: filename
+            expression: '/var/log/.*/cluster_(?P<cluster_id>\S+?)_logs/.*'
+        - labels:
+            cluster_id:
+        - regex:
+            expression: 'time="(?P<timestamp>[\w+T\d-:.Z]+)" level=(?P<level>[a-zA-Z]+) msg="(?P<msg>.+)"'
+        - timestamp:
+            source: timestamp
+            format: RFC3339Nano
+        - labels:
+            level:
+        - output:
+            source: msg
+- job_name: installer-gather
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: installer-gather
+      __path__: /var/log/*/*/log-bundle*/**/*.{txt,log,inspect}
+  pipeline_stages:
+    - match:
+        selector: '{job="installer-gather"}'
+        stages:
+        - regex:
+           source: filename
+           expression: '/var/log/.*/cluster_(?P<cluster_id>\S+?)_logs/'
+        - labels:
+           cluster_id:
+- job_name: must-gather
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: must-gather
+      __path__: /var/log/*/*/must-gather*/**/*.{txt,log,inspect,json,yaml}
+  pipeline_stages:
+    - match:
+        selector: '{job="must-gather"}'
+        stages:
+        - regex:
+           source: filename
+           expression: '/var/log/*/cluster_(?P<cluster_id>\S+?)_logs/'
+        - labels:
+           cluster_id:
+- job_name: cluster-events
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: cluster-events
+      __path__: /var/log/*/artifacts/cluster_*_events.json
+  pipeline_stages:
+  - multiline:
+      firstline: '(^\W+\{(.*))|([^\}\s]\s$)'
+  - replace:
+      expression: '(\n)'
+      replace: ''
+  - replace:
+      expression: '(\},)'
+      replace: '}'
+  - json:
+      expressions:
+        output: message
+        event_time: event_time
+        cluster_id: cluster_id
+        event_name: name
+        event_severity: severity
+  - timestamp:
+      source: event_time
+      format: RFC3339Nano
+  - labels:
+      cluster_id:
+      event_name:
+      event_severity:
+- job_name: infraenv-events
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: infraenv-events
+      __path__: /var/log/*/artifacts/infraenv_*_events.json
+  pipeline_stages:
+  - multiline:
+      firstline: '(^\W+\{(.*))|([^\}\s]\s$)'
+  - replace:
+      expression: '(\n)'
+      replace: ''
+  - replace:
+      expression: '(\},)'
+      replace: '}'
+  - json:
+      expressions:
+        output: message
+        event_time: event_time
+        cluster_id: cluster_id
+        host_id: host_id
+        infra_env_id: infra_env_id
+        event_name: name
+        event_severity: severity
+  - timestamp:
+      source: event_time
+      format: RFC3339Nano
+  - labels:
+      cluster_id:
+      event_name:
+      event_severity:
+      host_id:
+      infra_env_id:

--- a/triage/aitriage-to-loki/run-loki.py
+++ b/triage/aitriage-to-loki/run-loki.py
@@ -1,0 +1,26 @@
+import os
+import os.path
+import shutil
+from subprocess import run
+
+dest_dir = os.path.join("/tmp", "aitriage-loki")
+print(f"Re-creating {dest_dir}")
+shutil.rmtree(dest_dir, ignore_errors=True, onerror=None)
+os.makedirs(os.path.join(dest_dir, "promtail-data"))
+
+for subpath in ["promtail-data", "loki-data"]:
+    subdir = os.path.join(dest_dir, subpath)
+    shutil.rmtree(subdir, ignore_errors=True, onerror=None)
+    os.makedirs(subdir)
+
+print(f"Starting loki pod")
+podman_files_dir = os.path.join(dest_dir, "podman")
+shutil.rmtree(podman_files_dir, ignore_errors=True, onerror=None)
+shutil.copytree("podman", podman_files_dir)
+pod_path = os.path.join(dest_dir, "podman/pod.yml")
+run(["sed", "-i", f"s;foo;{dest_dir};g", pod_path])
+
+run(["podman", "pod", "rm", "-f", "aitriage-to-loki"])
+run(["podman", "play", "kube", pod_path])
+
+print(f"Grafana URL: http://localhost:3000/explore")

--- a/triage/aitriage-to-loki/unpack.py
+++ b/triage/aitriage-to-loki/unpack.py
@@ -1,0 +1,94 @@
+import os
+import os.path
+import sys
+import re
+import tarfile
+import tempfile
+import json
+import hashlib
+import shutil
+import urllib.request
+from subprocess import run
+
+if len(sys.argv) < 2:
+    print("Usage: unpack.py http://assisted-logs-collector.usersys.redhat.com/files/<log collector hash>")
+    sys.exit(1)
+
+
+class CollectorURLs:
+    clusterEventsJSON = None
+    clusterLogs = None
+    infraEnvJSON = None
+
+def newCollectorUrls(url_base):
+    cURL = CollectorURLs()
+
+    cluster_events_pattern = re.compile(r'cluster_\S+_events.json')
+    infraenv_events_pattern = re.compile(r'infraenv_\S+_events.json')
+
+    with urllib.request.urlopen(url_base) as response:
+        data = response.read()
+        encoding = response.info().get_content_charset('utf-8')
+        JSON_object = json.loads(data.decode(encoding))
+        for fileObj in JSON_object:
+            name = fileObj.get("name")
+            if not name:
+                continue
+            if name.endswith("_logs.tar"):
+                cURL.clusterLogs = url_base + "/" + name
+            if cluster_events_pattern.match(name):
+                cURL.clusterEventsJSON = url_base + "/" + name
+            if infraenv_events_pattern.match(name):
+                cURL.infraEnvJSON = url_base + "/" + name
+
+    if not cURL.clusterEventsJSON:
+        raise Exception("Failed to find cluster events JSON")
+    if not cURL.clusterLogs:
+        raise Exception("Failed to find cluster logs archive")
+    if not cURL.infraEnvJSON:
+        raise Exception("Failed to find infra events JSON")
+    return cURL
+
+baseURL = sys.argv[1]
+cluster_id = baseURL.split("/")[-1].split("_")[-1]
+print(f"Fetching {cluster_id} info from {baseURL}")
+
+collectorURLs = newCollectorUrls(baseURL)
+dest_dir = os.path.join("/tmp", "aitriage-loki", cluster_id)
+os.makedirs(dest_dir)
+artifacts_dir = os.path.join(dest_dir, "artifacts")
+
+print(f"Fetching files to {artifacts_dir}")
+os.makedirs(artifacts_dir)
+
+for field in ['clusterEventsJSON', 'clusterLogs', 'infraEnvJSON']:
+    url = getattr(collectorURLs, field)
+    filename = url.split("/")[-1]
+    with urllib.request.urlopen(url) as response:
+        dest_file = os.path.join(artifacts_dir, filename)
+        with open(dest_file, mode="wb") as tmp_file:
+            shutil.copyfileobj(response, tmp_file)
+            print(f"Fetched {url} to {dest_file}")
+
+if collectorURLs.clusterLogs:
+    print(f"Unpacking logs")
+    # extract the first tar file
+    filename = collectorURLs.clusterLogs.split("/")[-1]
+    logs_dst_dir = os.path.join(dest_dir, filename.split('.')[0])
+    filepath = os.path.join(artifacts_dir, filename)
+    file = tarfile.open(filepath)
+    file.extractall(logs_dst_dir)
+    file.close()
+
+    for filename in os.listdir(logs_dst_dir):
+        filepath = os.path.join(logs_dst_dir, filename)
+        if not os.path.isfile(filepath):
+            continue
+
+        print(f"Extracting {filename}")
+        file = tarfile.open(filepath)
+        file.extractall(logs_dst_dir)
+        file.close()
+
+
+print("Logs extracted")


### PR DESCRIPTION
These scripts are handy to analyze assisted-installer failure logs, running Loki-Grafana-Promtail stack to query logs from multiple sources