### PR TITLE
remove all bootlogs

### DIFF
--- a/operations/cloud-maintenance/README.md
+++ b/operations/cloud-maintenance/README.md
@@ -7,34 +7,11 @@ Scripts in this directory are meant to be deployed in the cloud.
 AWS maintenance scripts are deployed by using `aws-cli` image and the scripts deployed using
 a configmap. In this way we do not need to produce an artifact for this purpose.
 
-## S3 Cleanup script
+## S3 Bootlog Cleanup script
 
 S3 cleanup script accepts AWS bucket and access key/secret as env vars by referencing a secret with
-a well-known format (`AWS_S3_SECRET_NAME`) and a list of of folder (in AWS that would be object
-prefixes) to be removed.
+a well-known format (`AWS_S3_SECRET_NAME`).
 
-Example list of object prefixes:
-
-```yaml
-- name: OBJECTS_TO_BE_DELETED
-  value: "my-folder
-yet-another-folder
-example-folder
-your-folder"
-```
-
-Declaring a list like above would delete all objects with such prefix, for example:
-
-```
-my-folder/myfile.txt
-my-folder/anotherfile.txt
-my-folder/foo.txt
-yet-another-folder/bar.txt
-yet-another-folder/foobar.txt
-example-folder/mylog.log
-example-folder/apache.log
-example-folder/syslog.log
-...
-```
+The script will look for bootlog tar for each host, and remove it.
 
 The script defaults in dry-run mode, but it can overridden by emptying `S3_CLEANER_EXTRA_PARAMS` variable.

--- a/operations/cloud-maintenance/openshift/template.yaml
+++ b/operations/cloud-maintenance/openshift/template.yaml
@@ -24,8 +24,6 @@ parameters:
   value: Always
 - name: IMAGE_FULL_NAME
   value: quay.io/edge-infrastructure/aws-cli:2.11.3
-- name: OBJECTS_TO_BE_DELETED
-  required: true
 - name: S3_CLEANER_EXTRA_PARAMS
   value: "--dryrun"
 objects:
@@ -46,16 +44,11 @@ objects:
               configMap:
                 name: aws-scripts
                 defaultMode: 0755
-            - name: data
-              configMap:
-                name: aws-scripts-data
             containers:
             - name: aws-s3-cleaner
               image: ${IMAGE_FULL_NAME}
               imagePullPolicy: ${IMAGE_PULL_POLICY}
               volumeMounts:
-              - name: data
-                mountPath: /data/
               - name: scripts
                 mountPath: /scripts/delete_aws_s3_objects
                 subPath: delete_aws_s3_objects
@@ -67,7 +60,7 @@ objects:
                   memory: ${S3_CLEANER_MEMORY_REQUEST}
                   cpu: ${S3_CLEANER_CPU_REQUEST}
               command:
-              - /scripts/delete_aws_s3_objects
+              - /scripts/delete_aws_s3_bootlogs
               env:
               - name: LOGLEVEL
                 value: "${S3_CLEANER_LOGLEVEL}"
@@ -95,19 +88,18 @@ objects:
 - apiVersion: v1
   kind: ConfigMap
   metadata:
-    name: aws-scripts-data
-  data:
-    objects_to_be_deleted: |
-      ${OBJECTS_TO_BE_DELETED}
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
     name: aws-scripts
   data:
-    delete_aws_s3_objects: |
+    delete_aws_s3_bootlogs: |
       #!/bin/bash -e
-      echo "Reading patterns..."
-      for pattern in $(cat /data/objects_to_be_deleted); do
-        target=s3://${AWS_S3_BUCKET}/${pattern}
-        aws s3 rm ${S3_CLEANER_EXTRA_PARAMS} --recursive "${target}"
+      uuid_pattern="[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/"
+      # detect UUID-like directories to loop through clusters
+      for cluster_id in $(aws s3 ls s3://${AWS_S3_BUCKET} | grep -E "${uuid_pattern}" | awk '{ print $2 }' | sed 's/\///g'); do
+          echo "Checking cluster ${cluster_id} for boot logs"
+          # detect UUID-like directories to loop through hosts
+          for host_id in $(aws s3 ls "s3://${AWS_S3_BUCKET}/${cluster_id}/logs/" | grep -E "${uuid_pattern}" | awk '{ print $2 }' | sed 's/\///g'); do
+              echo "Checking cluster ${cluster_id} host ${host_id} for boot logs"
+              # remove boot logs, if there
+              aws s3 rm ${S3_CLEANER_EXTRA_PARAMS} "s3://${AWS_S3_BUCKET}/${cluster_id}/logs/${host_id}/boot_logs.tar.gz"
+          done
       done


### PR DESCRIPTION
This changes the cleanup script to remove *all bootlogs for all clusters* instead of *all data for specified clusters*.

Before we were removing also necessary data, possibly breaking affected clusters.
Now we will only remove boot logs, for affected and unaffected clusters.